### PR TITLE
Bug 1622662 Change WordBreaker.cpp to follow LLVM Standards

### DIFF
--- a/doc/1622662.patch
+++ b/doc/1622662.patch
@@ -1,0 +1,59 @@
+diff -r 9dd52a62f5df -r 80fcece45172 intl/lwbrk/WordBreaker.cpp
+--- a/intl/lwbrk/WordBreaker.cpp	Fri Mar 20 19:30:02 2020 +0200
++++ b/intl/lwbrk/WordBreaker.cpp	Fri Mar 20 14:43:46 2020 -0400
+@@ -54,32 +54,36 @@
+     if (IS_ASCII(c)) {
+       if (ASCII_IS_SPACE(c)) {
+         return kWbClassSpace;
+-      } else if (ASCII_IS_ALPHA(c) || ASCII_IS_DIGIT(c) ||
+-                 (c == '_' && !sStopAtUnderscore)) {
++      }
++      if (ASCII_IS_ALPHA(c) || ASCII_IS_DIGIT(c) ||
++          (c == '_' && !sStopAtUnderscore)) {
+         return kWbClassAlphaLetter;
+-      } else {
+-        return kWbClassPunct;
+       }
+-    } else if (IS_THAI(c)) {
++      return kWbClassPunct;
++    }
++    if (IS_THAI(c)) {
+       return kWbClassThaiLetter;
+-    } else if (c == 0x00A0 /*NBSP*/) {
++    }
++    if (c == 0x00A0 /*NBSP*/) {
+       return kWbClassSpace;
+-    } else {
+-      return kWbClassAlphaLetter;
+     }
+-  } else {
+-    if (IS_HAN(c)) {
+-      return kWbClassHanLetter;
+-    } else if (IS_KATAKANA(c)) {
+-      return kWbClassKatakanaLetter;
+-    } else if (IS_HIRAGANA(c)) {
+-      return kWbClassHiraganaLetter;
+-    } else if (IS_HALFWIDTHKATAKANA(c)) {
+-      return kWbClassHWKatakanaLetter;
+-    } else {
+-      return kWbClassAlphaLetter;
+-    }
++    return kWbClassAlphaLetter;
++  }
++
++  if (IS_HAN(c)) {
++    return kWbClassHanLetter;
++  }
++  if (IS_KATAKANA(c)) {
++    return kWbClassKatakanaLetter;
+   }
++  if (IS_HIRAGANA(c)) {
++    return kWbClassHiraganaLetter;
++  }
++  if (IS_HALFWIDTHKATAKANA(c)) {
++    return kWbClassHWKatakanaLetter;
++  }
++  return kWbClassAlphaLetter;
++
+   return static_cast<WordBreakClass>(0);
+ }

--- a/doc/a3.md
+++ b/doc/a3.md
@@ -1,0 +1,11 @@
+# CSC302 A3
+https://bugzilla.mozilla.org/show_bug.cgi?id=1622662
+
+## Diagnosis 
+The [LLVM Standards](http://clang.llvm.org/extra/clang-tidy/checks/readability-else-after-return.html) say that for better readability, indentations should be reduced, by avoiding the use of `else` or `else if` immidiately after something interrupts control in the program (ie `return`, `break`, `exit`, etc.). In `firefox-source/intl/lwbrk/WordBreaker.cpp`, this isn't followed as there are several `else if` and `else` statements that follow `return` statements. Fixing this bug will improve readability of the code. 
+
+## Solution
+I would go through `firefox-source/intl/lwbrk/WordBreaker.cpp` and for each `else` or `else if` statement following a `return`, I'd convert it simply to an `if` statement (if it was an `else if`), or simply remove the `else` (if it was an `else` statement). 
+
+## Testing
+As I am simply reformatting the code, the testing procedures need not change. The change can be verified by viewing the updated file. 

--- a/intl/lwbrk/WordBreaker.cpp
+++ b/intl/lwbrk/WordBreaker.cpp
@@ -54,32 +54,36 @@ WordBreakClass WordBreaker::GetClass(char16_t c) {
     if (IS_ASCII(c)) {
       if (ASCII_IS_SPACE(c)) {
         return kWbClassSpace;
-      } else if (ASCII_IS_ALPHA(c) || ASCII_IS_DIGIT(c) ||
-                 (c == '_' && !sStopAtUnderscore)) {
-        return kWbClassAlphaLetter;
-      } else {
-        return kWbClassPunct;
       }
-    } else if (IS_THAI(c)) {
+      if (ASCII_IS_ALPHA(c) || ASCII_IS_DIGIT(c) ||
+          (c == '_' && !sStopAtUnderscore)) {
+        return kWbClassAlphaLetter;
+      }
+      return kWbClassPunct;
+    }
+    if (IS_THAI(c)) {
       return kWbClassThaiLetter;
-    } else if (c == 0x00A0 /*NBSP*/) {
+    }
+    if (c == 0x00A0 /*NBSP*/) {
       return kWbClassSpace;
-    } else {
-      return kWbClassAlphaLetter;
     }
-  } else {
-    if (IS_HAN(c)) {
-      return kWbClassHanLetter;
-    } else if (IS_KATAKANA(c)) {
-      return kWbClassKatakanaLetter;
-    } else if (IS_HIRAGANA(c)) {
-      return kWbClassHiraganaLetter;
-    } else if (IS_HALFWIDTHKATAKANA(c)) {
-      return kWbClassHWKatakanaLetter;
-    } else {
-      return kWbClassAlphaLetter;
-    }
+    return kWbClassAlphaLetter;
   }
+
+  if (IS_HAN(c)) {
+    return kWbClassHanLetter;
+  }
+  if (IS_KATAKANA(c)) {
+    return kWbClassKatakanaLetter;
+  }
+  if (IS_HIRAGANA(c)) {
+    return kWbClassHiraganaLetter;
+  }
+  if (IS_HALFWIDTHKATAKANA(c)) {
+    return kWbClassHWKatakanaLetter;
+  }
+  return kWbClassAlphaLetter;
+
   return static_cast<WordBreakClass>(0);
 }
 


### PR DESCRIPTION
Follow LLVM standards vis-à-vis the use of `else` after `return` (which interrupts control). Read more [here](http://clang.llvm.org/extra/clang-tidy/checks/readability-else-after-return.html).
